### PR TITLE
Pause o jogo quando o aplicativo perder o foco

### DIFF
--- a/scenes/jogo_principal/jogo_principal.gd
+++ b/scenes/jogo_principal/jogo_principal.gd
@@ -287,6 +287,11 @@ func _input(event: InputEvent) -> void:
 		get_tree().paused = true
 
 
+func _notification(what: int):
+	if what == NOTIFICATION_APPLICATION_FOCUS_OUT:
+		pausar()
+
+
 func alterar_suporte(novo_suporte: int) -> void:
 	if (novo_suporte != GameManager.suporte):
 		GameManager.suporte = novo_suporte


### PR DESCRIPTION
Normalmente quando o usuário alterna para outro aplicativo outra janela, o que causa a perda do foco no jogo, o jogo é pausado automaticamente. Além dos impactos para a partida, isso também ajuda a reduzir o uso de recursos quando o jogo não está sendo jogado ativamente.

Sendo assim, agora o jogo será pausado quando o foco for perdido.