### PR TITLE
Substitua lógica com get_parent por sinais

### DIFF
--- a/UI/configurações_da_tela_inicial_teste.gd
+++ b/UI/configurações_da_tela_inicial_teste.gd
@@ -1,5 +1,8 @@
 extends Control
 
+signal música_desligada(desligada: bool)
+signal sons_mutados(mutados: bool)
+
 var ícone_fechar_normal: Resource = preload("res://assets/icons/close/close_normal.svg")
 var ícone_fechar_pressed: Resource = preload("res://assets/icons/close/close_pressed.svg")
 
@@ -77,11 +80,11 @@ func _on_botão_música_pressed() -> void:
 	
 	if GameManager.música_desligada:
 		$"Background/AspectRatioContainerBotãoMúsica/BotãoMúsica".icon = ícone_música_desligada_normal
-		get_parent().find_child("ContainerBotãoMúsica").find_child("BotãoMúsica").icon = ícone_música_desligada_normal
+		música_desligada.emit(true)
 		AudioServer.set_bus_mute(index_bus_música, true)
 	else:
 		$"Background/AspectRatioContainerBotãoMúsica/BotãoMúsica".icon = ícone_música_normal
-		get_parent().find_child("ContainerBotãoMúsica").find_child("BotãoMúsica").icon = ícone_música_normal
+		música_desligada.emit(false)
 		AudioServer.set_bus_mute(index_bus_música, false)
 
 
@@ -91,12 +94,12 @@ func _on_h_slider_música_value_changed(value: float) -> void:
 	if value == 0:
 		$"Background/AspectRatioContainerBotãoMúsica/BotãoMúsica".icon = ícone_música_desligada_normal
 		GameManager.música_desligada = true
-		get_parent().find_child("ContainerBotãoMúsica").find_child("BotãoMúsica").icon = ícone_música_desligada_normal
+		música_desligada.emit(true)
 		AudioServer.set_bus_mute(AudioServer.get_bus_index("Música"), true)
 	else:
 		$"Background/AspectRatioContainerBotãoMúsica/BotãoMúsica".icon = ícone_música_normal
 		GameManager.música_desligada = false
-		get_parent().find_child("ContainerBotãoMúsica").find_child("BotãoMúsica").icon = ícone_música_normal
+		música_desligada.emit(false)
 		AudioServer.set_bus_mute(AudioServer.get_bus_index("Música"), false)
 
 
@@ -121,11 +124,11 @@ func _on_botão_efeitos_sonoros_pressed() -> void:
 	
 	if GameManager.sons_mutados:
 		$"Background/AspectRatioContainerBotãoEfeitosSonoros/BotãoEfeitosSonoros".icon = ícone_sons_mudo_normal
-		get_parent().find_child("ContainerBotãoSons").find_child("BotãoSons").icon = ícone_sons_mudo_normal
+		sons_mutados.emit(true)
 		AudioServer.set_bus_mute(index_bust_sons, true)
 	else:
 		$"Background/AspectRatioContainerBotãoEfeitosSonoros/BotãoEfeitosSonoros".icon = ícone_sons_normal
-		get_parent().find_child("ContainerBotãoSons").find_child("BotãoSons").icon = ícone_sons_normal
+		sons_mutados.emit(false)
 		AudioServer.set_bus_mute(index_bust_sons, false)
 
 
@@ -134,12 +137,12 @@ func _on_h_slider_efeitos_sonoros_value_changed(value: float) -> void:
 	
 	if value == 0:
 		$"Background/AspectRatioContainerBotãoEfeitosSonoros/BotãoEfeitosSonoros".icon = ícone_sons_mudo_normal
-		get_parent().find_child("ContainerBotãoSons").find_child("BotãoSons").icon = ícone_sons_mudo_normal
+		sons_mutados.emit(true)
 		GameManager.sons_mutados = true
 		AudioServer.set_bus_mute(AudioServer.get_bus_index("SFX"), true)
 	else:
 		$"Background/AspectRatioContainerBotãoEfeitosSonoros/BotãoEfeitosSonoros".icon = ícone_sons_normal
-		get_parent().find_child("ContainerBotãoSons").find_child("BotãoSons").icon = ícone_sons_normal
+		sons_mutados.emit(false)
 		GameManager.sons_mutados = false
 		AudioServer.set_bus_mute(AudioServer.get_bus_index("SFX"), false)
 

--- a/UI/menu_pausa.gd
+++ b/UI/menu_pausa.gd
@@ -1,5 +1,8 @@
 extends Control
 
+signal barra_de_tempo_oculta(oculta: bool)
+signal número_de_vidas_mudou(vidas: int)
+
 
 var ícone_toggle_on: Resource = preload("res://assets/icons/toggle/toggle_on.svg")
 var ícone_toggle_off: Resource = preload("res://assets/icons/toggle/toggle_off.svg")
@@ -52,7 +55,7 @@ func _ready() -> void:
 	if GameManager.vidas != 2147483647:
 		$LineEditVidas.text = str(GameManager.vidas)
 	else:
-		$LineEditVidas.text = str(0)
+		$LineEditVidas.text = "Ilimitadas"
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta: float) -> void:
@@ -76,7 +79,7 @@ func _on_botão_voltar_ao_jogo_pressed() -> void:
 
 func _on_toggle_barra_de_tempo_toggled(toggled_on: bool) -> void:
 	GameManager.mostrar_barra_de_tempo = toggled_on
-	get_parent().get_parent().find_child("BarraDeTempo").visible = toggled_on
+	barra_de_tempo_oculta.emit(not toggled_on)
 	
 	$ToggleBarraDeTempo.icon = ícone_toggle_on if toggled_on else ícone_toggle_off
 
@@ -168,30 +171,27 @@ func _on_h_slider_sons_value_changed(value: float) -> void:
 
 
 func _on_line_edit_vidas_text_changed(new_text: String) -> void:
-	var label: Label = get_parent().find_child("LabelVidas")
-	var heart: Sprite2D = get_parent().find_child("Heart")
-	var heart_animation: AnimatedSprite2D = get_parent().find_child("HeartAnimation")
-	
 	var valor: int = int(new_text)
 	
 	if valor != 0:
 		GameManager.vidas = valor
-		label.visible = true
-		heart.visible = true
-		heart_animation.visible = true
-		label.text = str(valor)
+		número_de_vidas_mudou.emit(valor)
 	else:
 		GameManager.vidas = 2147483647
-		label.visible = false
-		heart.visible = false
-		heart_animation.visible = false
+		número_de_vidas_mudou.emit(2147483647)
 
 
 func _on_line_edit_vidas_text_submitted(new_text: String) -> void:
 	var valor: int = int(new_text)
 	
-	GameManager.vidas = valor
-	$LineEditVidas.text = str(valor)
+	if valor > 0:
+		GameManager.vidas = valor
+		$LineEditVidas.text = str(valor)
+		número_de_vidas_mudou.emit(valor)
+	else:
+		GameManager.vidas = 2147483647
+		$LineEditVidas.text = "Ilimitadas"
+		número_de_vidas_mudou.emit(2147483647)
 
 
 func _on_botão_finalizar_sessão_pressed() -> void:

--- a/UI/menu_pausa.tscn
+++ b/UI/menu_pausa.tscn
@@ -331,13 +331,13 @@ vertical_alignment = 1
 [node name="LineEditVidas" type="LineEdit" parent="."]
 layout_mode = 1
 anchors_preset = -1
-anchor_left = 0.641
+anchor_left = 0.553
 anchor_top = 0.73
 anchor_right = 0.746
 anchor_bottom = 0.806
-offset_left = 0.567993
+offset_left = -0.0560303
 offset_top = -0.0400085
-offset_right = -0.39209
+offset_right = -0.391968
 offset_bottom = -0.288025
 theme_override_colors/font_color = Color(1, 1, 1, 1)
 theme_override_font_sizes/font_size = 32

--- a/UI/tela_inicial_teste.gd
+++ b/UI/tela_inicial_teste.gd
@@ -41,6 +41,14 @@ func _on_botão_configurações_pressed() -> void:
 	$"ConfiguraçõesDaTelaInicialTeste".visible = true
 
 
+func _on_configurações_da_tela_inicial_teste_música_desligada(desligada: bool) -> void:
+	$"ContainerBotãoMúsica/BotãoMúsica".icon = ícone_música_desligada_normal if desligada else ícone_música_normal
+
+
+func _on_configurações_da_tela_inicial_teste_sons_mutados(mutados: bool) -> void:
+	$"ContainerBotãoSons/BotãoSons".icon = ícone_sons_mudo_normal if mutados else ícone_sons_normal
+
+
 func _on_botão_música_button_down() -> void:
 	if GameManager.música_desligada:
 		$"ContainerBotãoMúsica/BotãoMúsica".icon = ícone_música_desligada_pressionado

--- a/UI/tela_inicial_teste.tscn
+++ b/UI/tela_inicial_teste.tscn
@@ -251,3 +251,5 @@ layout_mode = 1
 [connection signal="button_down" from="ContainerBotãoSons/BotãoSons" to="." method="_on_botão_sons_button_down"]
 [connection signal="button_up" from="ContainerBotãoSons/BotãoSons" to="." method="_on_botão_sons_button_up"]
 [connection signal="pressed" from="ContainerBotãoSons/BotãoSons" to="." method="_on_botão_sons_pressed"]
+[connection signal="música_desligada" from="ConfiguraçõesDaTelaInicialTeste" to="." method="_on_configurações_da_tela_inicial_teste_música_desligada"]
+[connection signal="sons_mutados" from="ConfiguraçõesDaTelaInicialTeste" to="." method="_on_configurações_da_tela_inicial_teste_sons_mutados"]

--- a/scenes/alvos/brócolis/brócolis.gd
+++ b/scenes/alvos/brócolis/brócolis.gd
@@ -1,5 +1,6 @@
 extends Area2D
 
+signal tocado(tipo: int)
 
 const width: float = 101.1
 const height: float = 98.7
@@ -18,4 +19,4 @@ func _process(_delta: float) -> void:
 
 func _on_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
 	if event is InputEventMouseButton and event.pressed:
-		get_parent().clique(tipo)
+		tocado.emit(tipo)

--- a/scenes/alvos/cupcake/cupcake.gd
+++ b/scenes/alvos/cupcake/cupcake.gd
@@ -1,5 +1,6 @@
 extends Area2D
 
+signal tocado(tipo: int)
 
 const width: float = 95.5
 const height: float = 101.0
@@ -18,4 +19,4 @@ func _process(_delta: float) -> void:
 
 func _on_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
 	if event is InputEventMouseButton and event.pressed:
-		get_parent().clique(tipo)
+		tocado.emit(tipo)

--- a/scenes/alvos/donut/donut.gd
+++ b/scenes/alvos/donut/donut.gd
@@ -1,5 +1,6 @@
 extends Area2D
 
+signal tocado(tipo: int)
 
 const width: float = 106.0
 const height: float = 93.6
@@ -18,4 +19,4 @@ func _process(_delta: float) -> void:
 
 func _on_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
 	if event is InputEventMouseButton and event.pressed:
-		get_parent().clique(tipo)
+		tocado.emit(tipo)

--- a/scenes/alvos/hambúrguer/hambúrguer.gd
+++ b/scenes/alvos/hambúrguer/hambúrguer.gd
@@ -1,5 +1,6 @@
 extends Area2D
 
+signal tocado(tipo: int)
 
 const width: float = 106.5
 const height: float = 93.0
@@ -18,4 +19,4 @@ func _process(_delta: float) -> void:
 
 func _on_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
 	if event is InputEventMouseButton and event.pressed:
-		get_parent().clique(tipo)
+		tocado.emit(tipo)

--- a/scenes/alvos/maçã/maçã.gd
+++ b/scenes/alvos/maçã/maçã.gd
@@ -1,5 +1,6 @@
 extends Area2D
 
+signal tocado(tipo: int)
 
 const width: float = 108.75
 const height: float = 119.375
@@ -18,4 +19,4 @@ func _process(_delta: float) -> void:
 
 func _on_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
 	if event is InputEventMouseButton and event.pressed:
-		get_parent().clique(tipo)
+		tocado.emit(tipo)

--- a/scenes/alvos/ovo_frito/ovo_frito.gd
+++ b/scenes/alvos/ovo_frito/ovo_frito.gd
@@ -1,5 +1,6 @@
 extends Area2D
 
+signal tocado(tipo: int)
 
 const width: float = 115.75
 const height: float = 114.0
@@ -18,4 +19,4 @@ func _process(_delta: float) -> void:
 
 func _on_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
 	if event is InputEventMouseButton and event.pressed:
-		get_parent().clique(tipo)
+		tocado.emit(tipo)

--- a/scenes/alvos/picolé/picolé.gd
+++ b/scenes/alvos/picolé/picolé.gd
@@ -1,5 +1,6 @@
 extends Area2D
 
+signal tocado(tipo: int)
 
 const width: float = 51.6
 const height: float = 113.6
@@ -18,4 +19,4 @@ func _process(_delta: float) -> void:
 
 func _on_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
 	if event is InputEventMouseButton and event.pressed:
-		get_parent().clique(tipo)
+		tocado.emit(tipo)

--- a/scenes/alvos/pizza/pizza.gd
+++ b/scenes/alvos/pizza/pizza.gd
@@ -1,5 +1,6 @@
 extends Area2D
 
+signal tocado(tipo: int)
 
 const width: float = 111.0
 const height: float = 113.5
@@ -18,4 +19,4 @@ func _process(_delta: float) -> void:
 
 func _on_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
 	if event is InputEventMouseButton and event.pressed:
-		get_parent().clique(tipo)
+		tocado.emit(tipo)

--- a/scenes/alvos/sorvete/sorvete.gd
+++ b/scenes/alvos/sorvete/sorvete.gd
@@ -1,5 +1,6 @@
 extends Area2D
 
+signal tocado(tipo: int)
 
 const width: float = 67.6
 const height: float = 128.4
@@ -18,4 +19,4 @@ func _process(_delta: float) -> void:
 
 func _on_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
 	if event is InputEventMouseButton and event.pressed:
-		get_parent().clique(tipo)
+		tocado.emit(tipo)

--- a/scenes/alvos/uva/uva.gd
+++ b/scenes/alvos/uva/uva.gd
@@ -1,5 +1,6 @@
 extends Area2D
 
+signal tocado(tipo: int)
 
 const width: float = 106.4
 const height: float = 97.6
@@ -18,4 +19,4 @@ func _process(_delta: float) -> void:
 
 func _on_input_event(_viewport: Node, event: InputEvent, _shape_idx: int) -> void:
 	if event is InputEventMouseButton and event.pressed:
-		get_parent().clique(tipo)
+		tocado.emit(tipo)

--- a/scenes/game_manager/game_manager.gd
+++ b/scenes/game_manager/game_manager.gd
@@ -208,9 +208,9 @@ func iniciar_jogo_com_parâmetros(número_alvos: int = número_máximo_de_alvos,
 	iniciar_jogo()
 
 
-# Função de clique para verificar acerto
-func clique(alvos: Array[int]) -> bool:
-	# Se múltiplos alvos forem clicados em simultâneo devido à propagação do clique, o certo se sobrepõe aos errados
+# Função de toque para verificar acerto
+func toque(alvos: Array[int]) -> bool:
+	# Se múltiplos alvos forem clicados em simultâneo devido à propagação do toque, o certo se sobrepõe aos errados
 	if alvo_atual in alvos:
 		pontos_real += 1
 		pontos_display += 1

--- a/scenes/jogo_principal/jogo_principal.tscn
+++ b/scenes/jogo_principal/jogo_principal.tscn
@@ -367,3 +367,5 @@ position = Vector2(0, -113.6)
 [connection signal="button_down" from="CanvasLayer/ContainerBotãoPausa/BotãoPausa" to="." method="_on_botão_pausa_button_down"]
 [connection signal="button_up" from="CanvasLayer/ContainerBotãoPausa/BotãoPausa" to="." method="_on_botão_pausa_button_up"]
 [connection signal="pressed" from="CanvasLayer/ContainerBotãoPausa/BotãoPausa" to="." method="_on_botão_pausa_pressed"]
+[connection signal="barra_de_tempo_oculta" from="CanvasLayer/MenuPausa" to="." method="_on_menu_pausa_barra_de_tempo_oculta"]
+[connection signal="número_de_vidas_mudou" from="CanvasLayer/MenuPausa" to="." method="_on_menu_pausa_número_de_vidas_mudou"]


### PR DESCRIPTION
Havia lógica em diversas partes do código que utilizava get_parent para obter o nó pai e realizar determinadas ações, como alterar ícones ou sinalizar o toque. Isso causava coupling substancial, diminuindo o potencial de uso de determinadas cenas em outros contextos.

Esses casos foram substituídos por sinais, permitindo que o nó pai se conecte ao nó filho e receba notificações de eventos e os trate de sua forma, melhorando o encapsulamento e a modularidade.