### PR TITLE
Melhore o alinhamento dos itens da tela secreta

### DIFF
--- a/UI/tela_pré_teste.tscn
+++ b/UI/tela_pré_teste.tscn
@@ -68,41 +68,41 @@ horizontal_alignment = 1
 
 [node name="LabelProfissional" type="Label" parent="ScrollContainer/Control"]
 layout_mode = 2
-anchor_left = 0.036
+anchor_left = 0.042
 anchor_top = 0.235
-anchor_right = 0.49
+anchor_right = 0.495
 anchor_bottom = 0.269
-offset_left = 0.527992
+offset_left = -0.384003
 offset_top = 0.609985
-offset_right = -0.47998
-offset_bottom = -0.306091
+offset_right = -0.240051
+offset_bottom = -0.30603
 theme_override_font_sizes/font_size = 48
 text = "Profissional"
 
 [node name="LineEditProfissional" type="LineEdit" parent="ScrollContainer/Control"]
 layout_mode = 2
-anchor_left = 0.495
+anchor_left = 0.505
 anchor_top = 0.235
-anchor_right = 0.953
+anchor_right = 0.958
 anchor_bottom = 0.274
-offset_left = -0.240051
+offset_left = 0.23999
 offset_top = 0.609985
-offset_right = 0.143921
-offset_bottom = -0.676056
+offset_right = 0.383911
+offset_bottom = -0.676025
 theme_override_font_sizes/font_size = 48
 placeholder_text = "ID profissional"
 alignment = 1
 
 [node name="LabelNúmeroDeAlvos" type="Label" parent="ScrollContainer/Control"]
 layout_mode = 2
-anchor_left = 0.036
+anchor_left = 0.042
 anchor_top = 0.293
-anchor_right = 0.49
+anchor_right = 0.495
 anchor_bottom = 0.326
-offset_left = 0.527977
-offset_top = -0.482086
-offset_right = -0.47998
-offset_bottom = 0.275879
+offset_left = -0.384003
+offset_top = -0.482025
+offset_right = -0.240051
+offset_bottom = 0.276001
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_font_sizes/font_size = 48
@@ -110,13 +110,13 @@ text = "Número de alvos"
 
 [node name="LineEditNúmeroDeAlvos" type="LineEdit" parent="ScrollContainer/Control"]
 layout_mode = 2
-anchor_left = 0.495
+anchor_left = 0.505
 anchor_top = 0.293
-anchor_right = 0.952
+anchor_right = 0.958
 anchor_bottom = 0.331
-offset_left = -0.240051
-offset_top = -0.482056
-offset_right = 1.29602
+offset_left = 0.23999
+offset_top = -0.482025
+offset_right = 0.383911
 offset_bottom = -0.0940552
 theme_override_font_sizes/font_size = 48
 text = "10"
@@ -124,14 +124,14 @@ alignment = 1
 
 [node name="LabelRepetição" type="Label" parent="ScrollContainer/Control"]
 layout_mode = 2
-anchor_left = 0.036
+anchor_left = 0.042
 anchor_top = 0.35
-anchor_right = 0.49
+anchor_right = 0.495
 anchor_bottom = 0.384
-offset_left = 0.527992
-offset_top = 0.0999146
-offset_right = -0.47998
-offset_bottom = -0.81604
+offset_left = -0.384003
+offset_top = 0.0999756
+offset_right = -0.240051
+offset_bottom = -0.815979
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_font_sizes/font_size = 48
@@ -139,42 +139,42 @@ text = "Repetição máxima"
 
 [node name="LineEditRepetição" type="LineEdit" parent="ScrollContainer/Control"]
 layout_mode = 2
-anchor_left = 0.495
+anchor_left = 0.505
 anchor_top = 0.35
-anchor_right = 0.953
+anchor_right = 0.958
 anchor_bottom = 0.388
-offset_left = -0.240112
-offset_top = 0.0999146
-offset_right = 0.143921
-offset_bottom = 0.487915
+offset_left = 0.23999
+offset_top = 0.0999756
+offset_right = 0.383911
+offset_bottom = 0.487976
 theme_override_font_sizes/font_size = 48
 text = "3"
 alignment = 1
 
 [node name="LabelRequisito" type="Label" parent="ScrollContainer/Control"]
 layout_mode = 2
-anchor_left = 0.036
+anchor_left = 0.042
 anchor_top = 0.407
-anchor_right = 0.49
+anchor_right = 0.495
 anchor_bottom = 0.441
-offset_left = 0.527992
+offset_left = -0.384003
 offset_top = 0.682007
-offset_right = -0.47998
-offset_bottom = -0.23407
+offset_right = -0.240051
+offset_bottom = -0.234009
 theme_override_font_sizes/font_size = 48
 text = "Requisito"
 
 [node name="OptionButtonRequisito" type="OptionButton" parent="ScrollContainer/Control"]
 layout_mode = 1
 anchors_preset = -1
-anchor_left = 0.495
+anchor_left = 0.505
 anchor_top = 0.407
-anchor_right = 0.953
+anchor_right = 0.958
 anchor_bottom = 0.446
-offset_left = -0.240051
+offset_left = 0.23999
 offset_top = 0.682007
-offset_right = 0.143799
-offset_bottom = -0.604065
+offset_right = 0.383911
+offset_bottom = -0.604004
 theme_override_font_sizes/font_size = 48
 alignment = 1
 selected = 1
@@ -185,28 +185,28 @@ popup/item_1/id = 1
 
 [node name="LabelVelocidade" type="Label" parent="ScrollContainer/Control"]
 layout_mode = 2
-anchor_left = 0.036
+anchor_left = 0.042
 anchor_top = 0.465
-anchor_right = 0.49
+anchor_right = 0.495
 anchor_bottom = 0.498
-offset_left = 0.527992
-offset_top = -0.410095
-offset_right = -0.47998
-offset_bottom = 0.347778
+offset_left = -0.384003
+offset_top = -0.410034
+offset_right = -0.240051
+offset_bottom = 0.347961
 theme_override_font_sizes/font_size = 48
 text = "Velocidade"
 
 [node name="OptionButtonVelocidade" type="OptionButton" parent="ScrollContainer/Control"]
 layout_mode = 1
 anchors_preset = -1
-anchor_left = 0.495
+anchor_left = 0.505
 anchor_top = 0.465
-anchor_right = 0.953
+anchor_right = 0.958
 anchor_bottom = 0.503
-offset_left = -0.240051
-offset_top = -0.410095
-offset_right = 0.143799
-offset_bottom = -0.0220947
+offset_left = 0.23999
+offset_top = -0.410034
+offset_right = 0.383911
+offset_bottom = -0.0220337
 theme_override_font_sizes/font_size = 48
 alignment = 1
 selected = 2
@@ -221,14 +221,14 @@ popup/item_3/id = 3
 
 [node name="LabelVidas" type="Label" parent="ScrollContainer/Control"]
 layout_mode = 2
-anchor_left = 0.036
+anchor_left = 0.042
 anchor_top = 0.522
-anchor_right = 0.49
+anchor_right = 0.495
 anchor_bottom = 0.556
-offset_left = 0.527992
+offset_left = -0.384003
 offset_top = 0.171997
-offset_right = -0.47998
-offset_bottom = -0.744202
+offset_right = -0.240051
+offset_bottom = -0.74408
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_font_sizes/font_size = 48
@@ -236,28 +236,28 @@ text = "Vidas"
 
 [node name="LineEditVidas" type="LineEdit" parent="ScrollContainer/Control"]
 layout_mode = 2
-anchor_left = 0.495
+anchor_left = 0.505
 anchor_top = 0.522
-anchor_right = 0.952
+anchor_right = 0.958
 anchor_bottom = 0.56
-offset_left = -0.240112
+offset_left = 0.23999
 offset_top = 0.171997
-offset_right = 1.2959
-offset_bottom = 0.559875
+offset_right = 0.383911
+offset_bottom = 0.559998
 theme_override_font_sizes/font_size = 48
 text = "10"
 alignment = 1
 
 [node name="LabelDuração" type="Label" parent="ScrollContainer/Control"]
 layout_mode = 2
-anchor_left = 0.036
+anchor_left = 0.042
 anchor_top = 0.579
-anchor_right = 0.49
+anchor_right = 0.495
 anchor_bottom = 0.613
-offset_left = 0.527992
-offset_top = 0.754639
-offset_right = -0.47998
-offset_bottom = -0.162231
+offset_left = -0.384003
+offset_top = 0.753906
+offset_right = -0.240051
+offset_bottom = -0.162109
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_font_sizes/font_size = 48
@@ -265,42 +265,42 @@ text = "Duração (s)"
 
 [node name="LineEditDuração" type="LineEdit" parent="ScrollContainer/Control"]
 layout_mode = 2
-anchor_left = 0.495
+anchor_left = 0.505
 anchor_top = 0.579
-anchor_right = 0.952
+anchor_right = 0.958
 anchor_bottom = 0.618
-offset_left = -0.240051
-offset_top = 0.754639
-offset_right = 1.29602
-offset_bottom = -0.531372
+offset_left = 0.23999
+offset_top = 0.754883
+offset_right = 0.383911
+offset_bottom = -0.531128
 theme_override_font_sizes/font_size = 48
 text = "120"
 alignment = 1
 
 [node name="LabelReposicionamento" type="Label" parent="ScrollContainer/Control"]
 layout_mode = 2
-anchor_left = 0.036
+anchor_left = 0.042
 anchor_top = 0.637
-anchor_right = 0.49
+anchor_right = 0.495
 anchor_bottom = 0.67
-offset_left = 0.527992
-offset_top = -0.337402
-offset_right = -0.47998
-offset_bottom = 0.419922
+offset_left = -0.384003
+offset_top = -0.337036
+offset_right = -0.240051
+offset_bottom = 0.420898
 theme_override_font_sizes/font_size = 48
 text = "Reposicionamento"
 
 [node name="OptionButtonReposicionamento" type="OptionButton" parent="ScrollContainer/Control"]
 layout_mode = 1
 anchors_preset = -1
-anchor_left = 0.495
+anchor_left = 0.505
 anchor_top = 0.637
-anchor_right = 0.953
+anchor_right = 0.958
 anchor_bottom = 0.675
-offset_left = -0.240051
-offset_top = -0.337402
-offset_right = 0.143799
-offset_bottom = 0.0490723
+offset_left = 0.23999
+offset_top = -0.337036
+offset_right = 0.383911
+offset_bottom = 0.0509033
 theme_override_font_sizes/font_size = 48
 alignment = 1
 selected = 2
@@ -313,14 +313,14 @@ popup/item_2/id = 2
 
 [node name="LabelAnimações" type="Label" parent="ScrollContainer/Control"]
 layout_mode = 2
-anchor_left = 0.036
+anchor_left = 0.042
 anchor_top = 0.694
-anchor_right = 0.49
+anchor_right = 0.495
 anchor_bottom = 0.728
-offset_left = 0.527992
-offset_top = 0.244751
-offset_right = -0.47998
-offset_bottom = -0.672119
+offset_left = -0.384003
+offset_top = 0.244995
+offset_right = -0.240051
+offset_bottom = -0.671143
 theme_override_font_sizes/font_size = 48
 text = "Animações
 "
@@ -328,14 +328,14 @@ text = "Animações
 [node name="OptionButtonAnimações" type="OptionButton" parent="ScrollContainer/Control"]
 layout_mode = 1
 anchors_preset = -1
-anchor_left = 0.495
+anchor_left = 0.505
 anchor_top = 0.694
-anchor_right = 0.953
+anchor_right = 0.958
 anchor_bottom = 0.732
-offset_left = -0.240051
-offset_top = 0.244751
-offset_right = 0.143799
-offset_bottom = 0.63269
+offset_left = 0.23999
+offset_top = 0.244995
+offset_right = 0.383911
+offset_bottom = 0.632935
 theme_override_font_sizes/font_size = 48
 alignment = 1
 selected = 0
@@ -346,28 +346,28 @@ popup/item_1/id = 1
 
 [node name="LabelExibirTempo" type="Label" parent="ScrollContainer/Control"]
 layout_mode = 2
-anchor_left = 0.036
+anchor_left = 0.042
 anchor_top = 0.751
-anchor_right = 0.49
+anchor_right = 0.495
 anchor_bottom = 0.785
-offset_left = 0.527992
-offset_top = 0.826538
-offset_right = -0.47998
-offset_bottom = -0.09021
+offset_left = -0.384003
+offset_top = 0.826416
+offset_right = -0.240051
+offset_bottom = -0.0895996
 theme_override_font_sizes/font_size = 48
 text = "Exibir tempo"
 
 [node name="OptionButtonExibirTempo" type="OptionButton" parent="ScrollContainer/Control"]
 layout_mode = 1
 anchors_preset = -1
-anchor_left = 0.495
+anchor_left = 0.505
 anchor_top = 0.751
-anchor_right = 0.953
+anchor_right = 0.958
 anchor_bottom = 0.79
-offset_left = -0.240051
-offset_top = 0.826538
-offset_right = 0.143799
-offset_bottom = -0.459229
+offset_left = 0.23999
+offset_top = 0.825928
+offset_right = 0.383911
+offset_bottom = -0.460083
 theme_override_font_sizes/font_size = 48
 alignment = 1
 selected = 0
@@ -378,28 +378,28 @@ popup/item_1/id = 1
 
 [node name="LabelMúsica" type="Label" parent="ScrollContainer/Control"]
 layout_mode = 2
-anchor_left = 0.036
+anchor_left = 0.042
 anchor_top = 0.809
-anchor_right = 0.49
+anchor_right = 0.495
 anchor_bottom = 0.842
-offset_left = 0.527992
+offset_left = -0.384003
 offset_top = -0.265259
-offset_right = -0.47998
-offset_bottom = 0.491821
+offset_right = -0.240051
+offset_bottom = 0.492676
 theme_override_font_sizes/font_size = 48
 text = "Música"
 
 [node name="AspectRatioContainerBotãoMúsica" type="AspectRatioContainer" parent="ScrollContainer/Control"]
 layout_mode = 1
 anchors_preset = -1
-anchor_left = 0.495
+anchor_left = 0.505
 anchor_top = 0.806
-anchor_right = 0.55
+anchor_right = 0.561
 anchor_bottom = 0.845
-offset_left = -0.240051
+offset_left = 0.23999
 offset_top = 0.755859
-offset_right = 0.399963
-offset_bottom = -0.530029
+offset_right = -0.271973
+offset_bottom = -0.529907
 
 [node name="BotãoMúsica" type="Button" parent="ScrollContainer/Control/AspectRatioContainerBotãoMúsica"]
 layout_mode = 2
@@ -411,40 +411,40 @@ expand_icon = true
 [node name="HSliderMúsica" type="HSlider" parent="ScrollContainer/Control"]
 layout_mode = 1
 anchors_preset = -1
-anchor_left = 0.563
-anchor_top = 0.801
-anchor_right = 0.953
+anchor_left = 0.575
+anchor_top = 0.802
+anchor_right = 0.958
 anchor_bottom = 0.85
-offset_left = 0.42395
-offset_top = 1.12659
-offset_right = -0.856079
-offset_bottom = 0.100708
+offset_left = -0.400024
+offset_top = -0.547119
+offset_right = 0.383911
+offset_bottom = 0.100952
 value = 30.0
 
 [node name="LabelEfeitosSonoros" type="Label" parent="ScrollContainer/Control"]
 layout_mode = 2
-anchor_left = 0.036
+anchor_left = 0.042
 anchor_top = 0.866
-anchor_right = 0.49
+anchor_right = 0.495
 anchor_bottom = 0.9
-offset_left = 0.527992
-offset_top = 0.31665
-offset_right = -0.47998
-offset_bottom = -0.60022
+offset_left = -0.384003
+offset_top = 0.316528
+offset_right = -0.240051
+offset_bottom = -0.599487
 theme_override_font_sizes/font_size = 48
 text = "Efeitos Sonoros"
 
 [node name="AspectRatioContainerBotãoEfeitosSonoros" type="AspectRatioContainer" parent="ScrollContainer/Control"]
 layout_mode = 1
 anchors_preset = -1
-anchor_left = 0.495
+anchor_left = 0.505
 anchor_top = 0.864
-anchor_right = 0.55
+anchor_right = 0.561
 anchor_bottom = 0.902
-offset_left = -0.240051
+offset_left = 0.23999
 offset_top = -0.83606
-offset_right = 0.399963
-offset_bottom = -0.44812
+offset_right = -0.271973
+offset_bottom = -0.448242
 
 [node name="BotãoEfeitosSonoros" type="Button" parent="ScrollContainer/Control/AspectRatioContainerBotãoEfeitosSonoros"]
 layout_mode = 2
@@ -456,27 +456,27 @@ expand_icon = true
 [node name="HSliderEfeitosSonoros" type="HSlider" parent="ScrollContainer/Control"]
 layout_mode = 1
 anchors_preset = -1
-anchor_left = 0.563
+anchor_left = 0.575
 anchor_top = 0.859
-anchor_right = 0.952
+anchor_right = 0.958
 anchor_bottom = 0.907
-offset_left = 0.42395
-offset_top = 0.034668
-offset_right = 0.295898
-offset_bottom = 0.682617
+offset_left = -0.400024
+offset_top = 0.0349121
+offset_right = 0.383911
+offset_bottom = 0.682861
 value = 100.0
 
 [node name="BotãoIniciarMenu" type="Button" parent="ScrollContainer/Control"]
 layout_mode = 1
 anchors_preset = -1
-anchor_left = 0.036
+anchor_left = 0.042
 anchor_top = 0.924
-anchor_right = 0.49
+anchor_right = 0.495
 anchor_bottom = 0.981
-offset_left = 0.527992
-offset_top = -0.775269
-offset_right = -0.47998
-offset_bottom = -0.188599
+offset_left = -0.384003
+offset_top = -0.775024
+offset_right = -0.240051
+offset_bottom = -0.193115
 theme_override_font_sizes/font_size = 48
 text = "Iniciar (menu)"
 
@@ -487,9 +487,9 @@ anchor_left = 0.5
 anchor_top = 0.924
 anchor_right = 0.953
 anchor_bottom = 0.981
-offset_top = -0.380737
-offset_right = 0.143799
-offset_bottom = 0.205933
+offset_top = -0.776001
+offset_right = 0.143921
+offset_bottom = -0.194092
 theme_override_font_sizes/font_size = 48
 text = "Iniciar (jogo)"
 


### PR DESCRIPTION
Os campos e botões da tela secreta não estavam alinhados ao centro, agora eles estão corretamente em duas colunas de mesmo tamanho com 48 de espaço entre a borda da coluna e a borda da tela e 12 entre as colunas.