### PR TITLE
Permita a adição de múltiplos alvos iguais

### DIFF
--- a/UI/tela_inicial_teste.tscn
+++ b/UI/tela_inicial_teste.tscn
@@ -84,14 +84,16 @@ theme = ExtResource("2_areup")
 [node name="AspectRatioContainerBotãoConfigurações" type="AspectRatioContainer" parent="."]
 layout_mode = 1
 anchors_preset = -1
-anchor_left = 0.905
+anchor_left = 0.892
 anchor_right = 1.0
-anchor_bottom = 0.17
-offset_left = -0.560059
-offset_top = 10.0
-offset_right = -10.0
-offset_bottom = -0.160004
+anchor_bottom = 0.191
+offset_left = 0.416016
+offset_top = 24.0
+offset_right = -23.9999
+offset_bottom = 0.231987
 grow_horizontal = 2
+alignment_horizontal = 2
+alignment_vertical = 0
 
 [node name="BotãoConfigurações" type="Button" parent="AspectRatioContainerBotãoConfigurações"]
 layout_mode = 2

--- a/UI/tela_pré_teste.gd
+++ b/UI/tela_pré_teste.gd
@@ -164,11 +164,14 @@ func atualizar_id_profissional(new_text: String) -> void:
 func atualizar_número_de_alvos(new_text: String):
 	var número_de_alvos: int = int(new_text)
 	
-	if número_de_alvos <= 0:
-		número_de_alvos = 1
+	if número_de_alvos < GameManager.repetição_máxima:
+		número_de_alvos = GameManager.repetição_máxima
 	
 	if número_de_alvos > GameManager.número_máximo_de_alvos:
 		número_de_alvos = GameManager.número_máximo_de_alvos
+	
+	if número_de_alvos > GameManager.Alvos.size() * GameManager.repetição_máxima:
+		número_de_alvos = GameManager.Alvos.size() * GameManager.repetição_máxima
 	
 	$"ScrollContainer/Control/LineEditNúmeroDeAlvos".text = str(número_de_alvos)
 	GameManager.número_de_alvos = número_de_alvos
@@ -182,6 +185,9 @@ func atualizar_repetição(new_text: String) -> void:
 	
 	if repetição > GameManager.número_de_alvos:
 		repetição = GameManager.número_de_alvos
+	
+	if repetição * GameManager.Alvos.size() < GameManager.número_de_alvos:
+		repetição = ceil(float(GameManager.número_de_alvos) / GameManager.Alvos.size())
 	
 	$"ScrollContainer/Control/LineEditRepetição".text = str(repetição)
 	GameManager.repetição_máxima = repetição

--- a/UI/tela_pré_teste.tscn
+++ b/UI/tela_pré_teste.tscn
@@ -322,8 +322,7 @@ offset_top = 0.244995
 offset_right = -0.240051
 offset_bottom = -0.671143
 theme_override_font_sizes/font_size = 48
-text = "Animações
-"
+text = "Animações"
 
 [node name="OptionButtonAnimações" type="OptionButton" parent="ScrollContainer/Control"]
 layout_mode = 1

--- a/scenes/game_manager/game_manager.gd
+++ b/scenes/game_manager/game_manager.gd
@@ -51,7 +51,6 @@ var número_máximo_de_alvos: int
 var velocidade: int = Velocidades.MÉDIA
 var número_de_alvos: int
 var repetição_máxima: int = 3
-var alvos_no_jogo: Array
 var requisito: int = Requisitos.TODOS
 var política_de_reposicionamento: int = PolíticasDeReposicionamento.TODOS
 var alvo_atual: int = 0
@@ -77,75 +76,72 @@ var caminho: String = OS.get_system_dir(OS.SYSTEM_DIR_DOWNLOADS) + "/game_logs.c
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	linhas = round(tamanho_da_janela.y / tamanho_da_janela.x * colunas)
-	número_máximo_de_alvos = min(10, colunas * linhas - 1)
+	número_máximo_de_alvos = min(Alvos.size(), colunas * linhas - 1)
 
 	iniciar_música()
 	
 	var stylebox_slider: StyleBox = tema_menus_do_teste.get_stylebox("slider", "HSlider")
-	stylebox_slider.border_width_left *= GameManager.escala
-	stylebox_slider.border_width_top *= GameManager.escala
-	stylebox_slider.border_width_right *= GameManager.escala
-	stylebox_slider.border_width_bottom *= GameManager.escala
-	stylebox_slider.corner_radius_top_left *= GameManager.escala
-	stylebox_slider.corner_radius_top_right *= GameManager.escala
-	stylebox_slider.corner_radius_bottom_right *= GameManager.escala
-	stylebox_slider.corner_radius_bottom_left *= GameManager.escala
+	stylebox_slider.border_width_left *= escala
+	stylebox_slider.border_width_top *= escala
+	stylebox_slider.border_width_right *= escala
+	stylebox_slider.border_width_bottom *= escala
+	stylebox_slider.corner_radius_top_left *= escala
+	stylebox_slider.corner_radius_top_right *= escala
+	stylebox_slider.corner_radius_bottom_right *= escala
+	stylebox_slider.corner_radius_bottom_left *= escala
 	
 	var stylebox_grabber_area: StyleBox = tema_menus_do_teste.get_stylebox("grabber_area", "HSlider")
-	stylebox_grabber_area.border_width_left *= GameManager.escala
-	stylebox_grabber_area.border_width_top *= GameManager.escala
-	stylebox_grabber_area.border_width_right *= GameManager.escala
-	stylebox_grabber_area.border_width_bottom *= GameManager.escala
-	stylebox_grabber_area.corner_radius_top_left *= GameManager.escala
-	stylebox_grabber_area.corner_radius_top_right *= GameManager.escala
-	stylebox_grabber_area.corner_radius_bottom_right *= GameManager.escala
-	stylebox_grabber_area.corner_radius_bottom_left *= GameManager.escala
+	stylebox_grabber_area.border_width_left *= escala
+	stylebox_grabber_area.border_width_top *= escala
+	stylebox_grabber_area.border_width_right *= escala
+	stylebox_grabber_area.border_width_bottom *= escala
+	stylebox_grabber_area.corner_radius_top_left *= escala
+	stylebox_grabber_area.corner_radius_top_right *= escala
+	stylebox_grabber_area.corner_radius_bottom_right *= escala
+	stylebox_grabber_area.corner_radius_bottom_left *= escala
 	
 	var stylebox_grabber_area_highlight: StyleBox = tema_menus_do_teste.get_stylebox("grabber_area_highlight", "HSlider")
-	stylebox_grabber_area_highlight.border_width_left *= GameManager.escala
-	stylebox_grabber_area_highlight.border_width_top *= GameManager.escala
-	stylebox_grabber_area_highlight.border_width_right *= GameManager.escala
-	stylebox_grabber_area_highlight.border_width_bottom *= GameManager.escala
-	stylebox_grabber_area_highlight.corner_radius_top_left *= GameManager.escala
-	stylebox_grabber_area_highlight.corner_radius_top_right *= GameManager.escala
-	stylebox_grabber_area_highlight.corner_radius_bottom_right *= GameManager.escala
-	stylebox_grabber_area_highlight.corner_radius_bottom_left *= GameManager.escala
+	stylebox_grabber_area_highlight.border_width_left *= escala
+	stylebox_grabber_area_highlight.border_width_top *= escala
+	stylebox_grabber_area_highlight.border_width_right *= escala
+	stylebox_grabber_area_highlight.border_width_bottom *= escala
+	stylebox_grabber_area_highlight.corner_radius_top_left *= escala
+	stylebox_grabber_area_highlight.corner_radius_top_right *= escala
+	stylebox_grabber_area_highlight.corner_radius_bottom_right *= escala
+	stylebox_grabber_area_highlight.corner_radius_bottom_left *= escala
 	
 	var grabber_slider: CompressedTexture2D = tema_menus_do_teste.get_icon("grabber", "HSlider")
 	var grabber_slider_image: Image = grabber_slider.get_image()
-	grabber_slider_image.resize(int(grabber_slider.get_size().x * GameManager.escala), int(grabber_slider.get_size().y * GameManager.escala))
+	grabber_slider_image.resize(int(grabber_slider.get_size().x * escala), int(grabber_slider.get_size().y * escala))
 	var grabber_slider_texture: ImageTexture = ImageTexture.create_from_image(grabber_slider_image)
 	tema_menus_do_teste.set_icon("grabber", "HSlider", grabber_slider_texture)
 	
 	var grabber_disabled: CompressedTexture2D = tema_menus_do_teste.get_icon("grabber_disabled", "HSlider")
 	var grabber_disabled_image: Image = grabber_disabled.get_image()
-	grabber_disabled_image.resize(int(grabber_disabled.get_size().x * GameManager.escala), int(grabber_disabled.get_size().y * GameManager.escala))
+	grabber_disabled_image.resize(int(grabber_disabled.get_size().x * escala), int(grabber_disabled.get_size().y * escala))
 	var grabber_disabled_texture: ImageTexture = ImageTexture.create_from_image(grabber_disabled_image)
 	tema_menus_do_teste.set_icon("grabber_disabled", "HSlider", grabber_disabled_texture)
 	
 	var grabber_highlight: CompressedTexture2D = tema_menus_do_teste.get_icon("grabber_highlight", "HSlider")
 	var grabber_highlight_image: Image = grabber_highlight.get_image()
-	grabber_highlight_image.resize(int(grabber_highlight.get_size().x * GameManager.escala), int(grabber_highlight.get_size().y * GameManager.escala))
+	grabber_highlight_image.resize(int(grabber_highlight.get_size().x * escala), int(grabber_highlight.get_size().y * escala))
 	var grabber_highlight_texture: ImageTexture = ImageTexture.create_from_image(grabber_highlight_image)
 	tema_menus_do_teste.set_icon("grabber_highlight", "HSlider", grabber_highlight_texture)
 	
 	var radio_unchecked: CompressedTexture2D = tema_menus_do_teste.get_icon("radio_unchecked", "PopupMenu")
 	var radio_unchecked_image: Image = radio_unchecked.get_image()
-	radio_unchecked_image.resize(int(radio_unchecked.get_size().x * GameManager.escala), int(radio_unchecked.get_size().y * GameManager.escala))
+	radio_unchecked_image.resize(int(radio_unchecked.get_size().x * escala), int(radio_unchecked.get_size().y * escala))
 	var radio_unchecked_texture: ImageTexture = ImageTexture.create_from_image(radio_unchecked_image)
 	tema_menus_do_teste.set_icon("radio_unchecked", "PopupMenu", radio_unchecked_texture)
 	
 	var radio_checked: CompressedTexture2D = tema_menus_do_teste.get_icon("radio_checked", "PopupMenu")
 	var radio_checked_image: Image = radio_checked.get_image()
-	radio_checked_image.resize(int(radio_checked.get_size().x * GameManager.escala), int(radio_checked.get_size().y * GameManager.escala))
+	radio_checked_image.resize(int(radio_checked.get_size().x * escala), int(radio_checked.get_size().y * escala))
 	var radio_checked_texture: ImageTexture = ImageTexture.create_from_image(radio_checked_image)
 	tema_menus_do_teste.set_icon("radio_checked", "PopupMenu", radio_checked_texture)
 	
 	# Só relevante para debug quando iniciando a cena do jogo principal diretamente.
 	número_de_alvos = número_máximo_de_alvos
-	alvos_no_jogo = Alvos.values()
-	alvos_no_jogo.shuffle()
-	alvos_no_jogo = alvos_no_jogo.slice(0, número_de_alvos)
 
 
 # Chamado a cada frame
@@ -174,11 +170,7 @@ func parar_música() -> void:
 
 
 func iniciar_jogo() -> void:
-	alvos_no_jogo = Alvos.values()
-	alvos_no_jogo.shuffle()
-	alvos_no_jogo = alvos_no_jogo.slice(0, número_de_alvos)
 	
-	alvo_atual = alvos_no_jogo.pick_random()
 	
 	pontos_real = 0
 	pontos_display = 0
@@ -211,42 +203,36 @@ func iniciar_jogo_com_parâmetros(número_alvos: int = número_máximo_de_alvos,
 	iniciar_jogo()
 
 
-# Função de toque para verificar acerto
-func toque(alvos: Array[int]) -> bool:
-	# Se múltiplos alvos forem clicados em simultâneo devido à propagação do toque, o certo se sobrepõe aos errados
-	if alvo_atual in alvos:
-		pontos_real += 1
-		pontos_display += 1
-		
-		var anterior: int = alvo_atual
-		
-		# O alvo novo sempre será diferente do anterior
-		while alvo_atual == anterior and alvos_no_jogo.size() > 1:
-			alvo_atual = alvos_no_jogo.pick_random()
+func acerto_intermediário() -> void:
+	log_data.append([id_sessão, id_profissional, data_sessão, timestamp_atual_sessão, nome_jogo, tempo_resposta, pontos_real, alvo_atual, "INTERMEDIÁRIO", suporte, Velocidades.find_key(velocidade), vidas])
+	salvar_logs_csv()
 
-		# Adiciona os dados ao log
-		log_data.append([id_sessão, id_profissional, data_sessão, timestamp_atual_sessão, nome_jogo, tempo_resposta, pontos_real, alvo_atual, true, suporte, Velocidades.find_key(velocidade), vidas]) # Exemplo de log com acerto
-		salvar_logs_csv()
-		
-		tempo_resposta = 0.0
-		
-		return true
-	else:
-		if pontos_display >= 1:
-			pontos_display -= 1
-		
-		pontos_real -= 1
-		
-		if vidas != INT_MAX:
-			vidas -= 1
-		
-		log_data.append([id_sessão, id_profissional, data_sessão, timestamp_atual_sessão, nome_jogo, tempo_resposta, pontos_real, alvo_atual, false, suporte, Velocidades.find_key(velocidade), vidas])  # Exemplo de log com erro
-		salvar_logs_csv()
-		
-		if vidas == 0:
-			finalizar_sessão()
-		
-		return false
+
+func acerto_final() -> void:
+	pontos_real += 1
+	pontos_display += 1
+	
+	# Adiciona os dados ao log
+	log_data.append([id_sessão, id_profissional, data_sessão, timestamp_atual_sessão, nome_jogo, tempo_resposta, pontos_real, alvo_atual, "FINAL", suporte, Velocidades.find_key(velocidade), vidas])
+	salvar_logs_csv()
+	
+	tempo_resposta = 0.0
+
+
+func erro() -> void:
+	if pontos_display >= 1:
+		pontos_display -= 1
+	
+	pontos_real -= 1
+	
+	if vidas != INT_MAX:
+		vidas -= 1
+	
+	if vidas == 0:
+		finalizar_sessão()
+	
+	log_data.append([id_sessão, id_profissional, data_sessão, timestamp_atual_sessão, nome_jogo, tempo_resposta, pontos_real, alvo_atual, "ERRO", suporte, Velocidades.find_key(velocidade), vidas])
+	salvar_logs_csv()
 
 
 func mudança_no_suporte() -> void:

--- a/scenes/jogo_principal/jogo_principal.tscn
+++ b/scenes/jogo_principal/jogo_principal.tscn
@@ -1,26 +1,15 @@
-[gd_scene load_steps=74 format=3 uid="uid://c1kieko08207m"]
+[gd_scene load_steps=63 format=3 uid="uid://c1kieko08207m"]
 
 [ext_resource type="Script" path="res://scenes/jogo_principal/jogo_principal.gd" id="1_56i3e"]
 [ext_resource type="Theme" uid="uid://dejubhbtuxstt" path="res://scenes/jogo_principal/jogo_principal.tres" id="1_u5hf3"]
 [ext_resource type="Texture2D" uid="uid://11emcp3oxcn0" path="res://assets/background.png" id="2_1oknb"]
 [ext_resource type="AudioStream" uid="uid://trmfjw1qgyrb" path="res://assets/sounds/tap_right/tap.wav" id="2_4ap5s"]
 [ext_resource type="PackedScene" uid="uid://b220by45y5bjv" path="res://UI/menu_pausa.tscn" id="2_7sorp"]
-[ext_resource type="PackedScene" uid="uid://x8gr2llucnrv" path="res://scenes/alvos/donut/donut.tscn" id="2_33l3o"]
 [ext_resource type="Texture2D" uid="uid://ckybi4o6hyssl" path="res://assets/current_target_box.png" id="3_jvdrf"]
 [ext_resource type="AudioStream" uid="uid://baiwynv4mx0pu" path="res://assets/sounds/tap_wrong/tap_wrong.wav" id="3_p3tf5"]
-[ext_resource type="PackedScene" uid="uid://bi3p0yl1fdvr0" path="res://scenes/alvos/hambúrguer/hambúrguer.tscn" id="5_fjpxd"]
-[ext_resource type="Texture2D" uid="uid://cinv4qjjnqqkr" path="res://assets/current_target_box_hollow.png" id="6_40f5l"]
-[ext_resource type="PackedScene" uid="uid://b4mh3kec83g0j" path="res://scenes/alvos/pizza/pizza.tscn" id="6_51a2h"]
-[ext_resource type="PackedScene" uid="uid://s0jn048bopew" path="res://scenes/alvos/cupcake/cupcake.tscn" id="7_0dske"]
-[ext_resource type="PackedScene" uid="uid://5g0i2x5vfdmt" path="res://scenes/alvos/sorvete/sorvete.tscn" id="7_6ogpa"]
-[ext_resource type="PackedScene" uid="uid://bjfk2g5gmsslm" path="res://scenes/alvos/picolé/picolé.tscn" id="7_30t43"]
-[ext_resource type="PackedScene" uid="uid://vj7r1qeedxms" path="res://scenes/alvos/uva/uva.tscn" id="7_ll5sl"]
-[ext_resource type="PackedScene" uid="uid://c1qxkoehka503" path="res://scenes/alvos/ovo_frito/ovo_frito.tscn" id="7_nnegn"]
-[ext_resource type="PackedScene" uid="uid://cj3bcuy8meobn" path="res://scenes/alvos/brócolis/brócolis.tscn" id="7_oa5at"]
 [ext_resource type="Texture2D" uid="uid://8edpe3tkcgwd" path="res://assets/sprites/heart/heart.png" id="7_qiex0"]
 [ext_resource type="Texture2D" uid="uid://cm5yds4g3w4bf" path="res://assets/progressbar.png" id="8_h2bnm"]
 [ext_resource type="Texture2D" uid="uid://dn286hidgc5je" path="res://assets/sprites/heart/animation/0001.png" id="8_mtde2"]
-[ext_resource type="PackedScene" uid="uid://crxyuw6h3xx20" path="res://scenes/alvos/maçã/maçã.tscn" id="8_wa8v5"]
 [ext_resource type="Texture2D" uid="uid://bsfilprn15xit" path="res://assets/sprites/heart/animation/0002.png" id="9_iw1ci"]
 [ext_resource type="Texture2D" uid="uid://4544giyyt5bc" path="res://assets/sprites/heart/animation/0003.png" id="10_h0m8x"]
 [ext_resource type="Texture2D" uid="uid://cl3620u536hp6" path="res://assets/sprites/heart/animation/0004.png" id="11_frwhn"]
@@ -259,11 +248,12 @@ theme = ExtResource("1_u5hf3")
 theme_override_font_sizes/font_size = 64
 text = "0"
 
-[node name="AjudaAlvo" type="TextureRect" parent="CanvasLayer"]
-offset_top = -150.0
-offset_right = 150.0
-texture = ExtResource("6_40f5l")
-expand_mode = 2
+[node name="ControlSuporte" type="Control" parent="CanvasLayer"]
+layout_mode = 3
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+mouse_filter = 1
 
 [node name="ControlAlvo" type="Control" parent="CanvasLayer"]
 layout_mode = 3
@@ -296,14 +286,15 @@ sprite_frames = SubResource("SpriteFrames_eqsfm")
 
 [node name="ContainerBotãoPausa" type="AspectRatioContainer" parent="CanvasLayer"]
 anchors_preset = -1
-anchor_left = 0.9
-anchor_top = 0.023
-anchor_right = 0.987
-anchor_bottom = 0.177
-offset_left = 0.199951
-offset_top = 0.0959988
-offset_right = -0.0240479
-offset_bottom = 0.304001
+anchor_left = 0.892
+anchor_right = 1.0
+anchor_bottom = 0.191
+offset_left = 0.416016
+offset_top = 24.0
+offset_right = -24.0
+offset_bottom = 0.231987
+alignment_horizontal = 2
+alignment_vertical = 0
 
 [node name="BotãoPausa" type="Button" parent="CanvasLayer/ContainerBotãoPausa"]
 layout_mode = 2
@@ -333,36 +324,6 @@ texture = ExtResource("2_1oknb")
 position = Vector2(576, 632)
 scale = Vector2(36, 1)
 texture = ExtResource("8_h2bnm")
-
-[node name="Donut" parent="." instance=ExtResource("2_33l3o")]
-position = Vector2(0, -93.6)
-
-[node name="Hambúrguer" parent="." instance=ExtResource("5_fjpxd")]
-position = Vector2(0, -93)
-
-[node name="Pizza" parent="." instance=ExtResource("6_51a2h")]
-position = Vector2(0, -113.5)
-
-[node name="OvoFrito" parent="." instance=ExtResource("7_nnegn")]
-position = Vector2(0, -114)
-
-[node name="Maçã" parent="." instance=ExtResource("8_wa8v5")]
-position = Vector2(0, -119.375)
-
-[node name="Uva" parent="." instance=ExtResource("7_ll5sl")]
-position = Vector2(0, -97.6)
-
-[node name="Sorvete" parent="." instance=ExtResource("7_6ogpa")]
-position = Vector2(0, -128.4)
-
-[node name="Cupcake" parent="." instance=ExtResource("7_0dske")]
-position = Vector2(0, -101)
-
-[node name="Brócolis" parent="." instance=ExtResource("7_oa5at")]
-position = Vector2(0, -98.7)
-
-[node name="Picolé" parent="." instance=ExtResource("7_30t43")]
-position = Vector2(0, -113.6)
 
 [connection signal="button_down" from="CanvasLayer/ContainerBotãoPausa/BotãoPausa" to="." method="_on_botão_pausa_button_down"]
 [connection signal="button_up" from="CanvasLayer/ContainerBotãoPausa/BotãoPausa" to="." method="_on_botão_pausa_button_up"]

--- a/scenes/suporte/suporte.tscn
+++ b/scenes/suporte/suporte.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=3 uid="uid://buenxbyfefe56"]
+
+[ext_resource type="Texture2D" uid="uid://cinv4qjjnqqkr" path="res://assets/current_target_box_hollow.png" id="1_t5jde"]
+
+[node name="Suporte" type="TextureRect"]
+offset_right = 150.0
+offset_bottom = 150.0
+texture = ExtResource("1_t5jde")
+expand_mode = 2


### PR DESCRIPTION
A lógica do jogo foi substancialmente alterada para permitir que haja múltiplos alvos iguais na tela.

É possível configurar se apenas um alvo precisa ser tocado para pontuar ou se todos os alvos iguais precisam ser tocados para pontuar. Se todos precisam ser tocados os alvos tocados desaparecem e só são reposicionados de acordo com a política de reposicionamento após todos os alvos terem sido tocados e um ponto marcado.

Agora os alvos não são mais instâncias estáticas na cena, mas sim instâncias dinâmicas que são criadas no início da cena do jogo principal.

Virtualmente toda a lógica de pontuação foi reescrita para trabalhar com esta nova abordagem. O GameManager agora é menos responsável por questões do jogo, como determinar se um toque foi certo ou não, agora essas responsabilidades são delegadas para o jogo principal.