### PR TITLE
Corrija os indicadores nem sempre se atualizarem

### DIFF
--- a/UI/menu_pausa.gd
+++ b/UI/menu_pausa.gd
@@ -1,8 +1,7 @@
 extends Control
 
-signal barra_de_tempo_oculta(oculta: bool)
-signal número_de_vidas_mudou(vidas: int)
 
+signal barra_de_tempo_oculta(oculta: bool)
 
 var ícone_toggle_on: Resource = preload("res://assets/icons/toggle/toggle_on.svg")
 var ícone_toggle_off: Resource = preload("res://assets/icons/toggle/toggle_off.svg")
@@ -56,6 +55,11 @@ func _ready() -> void:
 		$LineEditVidas.text = str(GameManager.vidas)
 	else:
 		$LineEditVidas.text = "Ilimitadas"
+	
+	GameManager.mudança_nas_vidas.connect(func(vidas: int) -> void:
+		if not $LineEditVidas.has_focus():
+			$LineEditVidas.text = str(vidas)
+	)
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta: float) -> void:
@@ -173,12 +177,11 @@ func _on_h_slider_sons_value_changed(value: float) -> void:
 func _on_line_edit_vidas_text_changed(new_text: String) -> void:
 	var valor: int = int(new_text)
 	
-	if valor != 0:
-		GameManager.vidas = valor
-		número_de_vidas_mudou.emit(valor)
-	else:
-		GameManager.vidas = GameManager.INT_MAX
-		número_de_vidas_mudou.emit(GameManager.INT_MAX)
+	if valor <= 0:
+		valor = GameManager.INT_MAX
+	
+	GameManager.vidas = valor
+	GameManager.alterar_número_de_vidas(valor)
 
 
 func _on_line_edit_vidas_text_submitted(new_text: String) -> void:
@@ -188,7 +191,7 @@ func _on_line_edit_vidas_text_submitted(new_text: String) -> void:
 		valor = GameManager.INT_MAX
 	
 	GameManager.vidas = valor
-	número_de_vidas_mudou.emit(valor)
+	GameManager.alterar_número_de_vidas(valor)
 
 	if valor == GameManager.INT_MAX:
 		$"LineEditVidas".text = "Ilimitadas"

--- a/scenes/game_manager/game_manager.gd
+++ b/scenes/game_manager/game_manager.gd
@@ -1,6 +1,9 @@
 extends Node2D
 
 
+signal mudança_nas_vidas(vidas: int)
+signal mudança_nos_pontos(pontos_real: int, pontos_display: int)
+
 const INT_MIN: int = -9223372036854775808
 const INT_MAX: int = 9223372036854775807
 
@@ -167,8 +170,6 @@ func parar_música() -> void:
 
 
 func iniciar_jogo() -> void:
-	
-	
 	pontos_real = 0
 	pontos_display = 0
 	suporte = 0
@@ -209,6 +210,8 @@ func acerto_final() -> void:
 	pontos_real += 1
 	pontos_display += 1
 	
+	mudança_nos_pontos.emit(pontos_real, pontos_display)
+	
 	# Adiciona os dados ao log
 	log_data.append([id_sessão, id_profissional, data_sessão, timestamp_atual_sessão, nome_jogo, tempo_resposta, pontos_real, alvo_atual, "FINAL", suporte, Velocidades.find_key(velocidade), vidas])
 	salvar_logs_csv()
@@ -222,14 +225,22 @@ func erro() -> void:
 	
 	pontos_real -= 1
 	
+	mudança_nos_pontos.emit(pontos_real, pontos_display)
+	
 	if vidas != INT_MAX:
 		vidas -= 1
+		mudança_nas_vidas.emit(vidas)
 	
 	if vidas == 0:
 		finalizar_sessão()
 	
 	log_data.append([id_sessão, id_profissional, data_sessão, timestamp_atual_sessão, nome_jogo, tempo_resposta, pontos_real, alvo_atual, "ERRO", suporte, Velocidades.find_key(velocidade), vidas])
 	salvar_logs_csv()
+
+
+func alterar_número_de_vidas(número_de_vidas: int) -> void:
+	vidas = número_de_vidas
+	mudança_nas_vidas.emit(vidas)
 
 
 func mudança_no_suporte() -> void:

--- a/scenes/jogo_principal/jogo_principal.gd
+++ b/scenes/jogo_principal/jogo_principal.gd
@@ -61,9 +61,6 @@ const TEMPO_ATÉ_AUMENTAR_O_SUPORTE: float = 5.0
 func _ready() -> void:
 	tamanho_da_janela = get_viewport_rect().size
 	
-	atualizar_placar()
-	atualizar_vidas()
-	
 	GameManager.alvo_atual = alvo_aleatório()
 	repetição = repetição_aleatória()
 	
@@ -188,11 +185,6 @@ func _ready() -> void:
 	
 	$CanvasLayer/LabelPontos.add_theme_font_size_override("font_size", GameManager.escala * TAMANHO_BASE_DA_FONTE)
 	$CanvasLayer/LabelVidas.add_theme_font_size_override("font_size", GameManager.escala * TAMANHO_BASE_DA_FONTE)
-
-	if GameManager.vidas == GameManager.INT_MAX:
-		$CanvasLayer/LabelVidas.visible = false
-		$CanvasLayer/Heart.visible = false
-		$CanvasLayer/HeartAnimation.visible = false
 		
 	$CanvasLayer/Heart.global_position *= GameManager.escala
 	$CanvasLayer/HeartAnimation.global_position *= GameManager.escala
@@ -201,6 +193,14 @@ func _ready() -> void:
 	$CanvasLayer/Heart.scale *= GameManager.escala
 	$CanvasLayer/HeartAnimation.scale *= GameManager.escala
 	$CanvasLayer/Star.scale *= GameManager.escala
+	
+	atualizar_placar(GameManager.pontos_display)
+	GameManager.mudança_nos_pontos.connect(func(_pontos_real, pontos_display) -> void:
+		atualizar_placar(pontos_display)
+	)
+	
+	atualizar_vidas(GameManager.vidas)
+	GameManager.mudança_nas_vidas.connect(atualizar_vidas)
 #endregion
 
 	spawnar_todos_os_alvos()
@@ -265,8 +265,6 @@ func _process(delta: float) -> void:
 				if GameManager.animar:
 					$CanvasLayer/Star.play()
 				
-				atualizar_placar()
-				
 				alterar_suporte(0)
 				tempo_desde_toque_certo = 0.0
 				
@@ -328,8 +326,6 @@ func _process(delta: float) -> void:
 				tempo_desde_toque_certo = floor(tempo_desde_toque_certo / TEMPO_ATÉ_AUMENTAR_O_SUPORTE) * TEMPO_ATÉ_AUMENTAR_O_SUPORTE
 		else:
 			GameManager.erro()
-			
-			atualizar_vidas()
 			
 			if GameManager.vidas > 0:
 				$TapWrong.play()
@@ -413,15 +409,21 @@ func setar_sprite_alvo(tipo: int) -> void:
 	
 	$CanvasLayer/ControlAlvo.add_child(sprites_dos_alvos[tipo])
 	sprite_do_alvo_atual = sprites_dos_alvos[tipo]
-
-
-func atualizar_placar() -> void:
-	$CanvasLayer/LabelPontos.text = str(GameManager.pontos_display)
 	
+func atualizar_placar(pontos: int) -> void:
+	$CanvasLayer/LabelPontos.text = str(pontos)
 
-func atualizar_vidas() -> void:
-	if GameManager.vidas != GameManager.INT_MAX:
-		$CanvasLayer/LabelVidas.text = str(GameManager.vidas)
+
+func atualizar_vidas(vidas: int) -> void:
+	if vidas != GameManager.INT_MAX:
+		$CanvasLayer/LabelVidas.visible = true
+		$CanvasLayer/Heart.visible = true
+		$CanvasLayer/HeartAnimation.visible = true
+		$CanvasLayer/LabelVidas.text = str(vidas)
+	else:
+		$CanvasLayer/LabelVidas.visible = false
+		$CanvasLayer/Heart.visible = false
+		$CanvasLayer/HeartAnimation.visible = false
 
 
 func alvo_aleatório_presente() -> int:
@@ -654,16 +656,3 @@ func _on_botão_pausa_pressed() -> void:
 
 func _on_menu_pausa_barra_de_tempo_oculta(oculta: bool) -> void:
 	$BarraDeTempo.visible = not oculta
-
-
-func _on_menu_pausa_número_de_vidas_mudou(vidas: int) -> void:
-	if vidas == GameManager.INT_MAX:
-		$CanvasLayer/LabelVidas.visible = false
-		$CanvasLayer/Heart.visible = false
-		$CanvasLayer/HeartAnimation.visible = false
-	else:
-		$CanvasLayer/LabelVidas.visible = true
-		$CanvasLayer/Heart.visible = true
-		$CanvasLayer/HeartAnimation.visible = true
-		$CanvasLayer/LabelVidas.text = str(vidas)
-		

--- a/scenes/jogo_principal/jogo_principal.tscn
+++ b/scenes/jogo_principal/jogo_principal.tscn
@@ -329,4 +329,3 @@ texture = ExtResource("8_h2bnm")
 [connection signal="button_up" from="CanvasLayer/ContainerBotãoPausa/BotãoPausa" to="." method="_on_botão_pausa_button_up"]
 [connection signal="pressed" from="CanvasLayer/ContainerBotãoPausa/BotãoPausa" to="." method="_on_botão_pausa_pressed"]
 [connection signal="barra_de_tempo_oculta" from="CanvasLayer/MenuPausa" to="." method="_on_menu_pausa_barra_de_tempo_oculta"]
-[connection signal="número_de_vidas_mudou" from="CanvasLayer/MenuPausa" to="." method="_on_menu_pausa_número_de_vidas_mudou"]


### PR DESCRIPTION
Os indicadores de pontos e vidas nem sempre se atualizavam corretamente. Em alguns casos pontos eram ganhos ou perdidos ou vidas perdidas sem que o indicador fosse atualizado. Isso ocorria pois havia uma dependência local de atualização dos indicadores sempre que pudessem mudar.

Agora a responsabilidade de informar se indicadores devem ser atualizados é do GameManager, que emitirá sinais `mudança_nos_pontos` e `mudança_nas_vidas`. O jogo principal e o menu de pausa escutam estes sinais e sempre atualizam os indicadores sem depender de que seja localmente previsto que eventos possam causar mudanças nos pontos ou nas vidas.